### PR TITLE
add jquery.json-view.css to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,10 @@
     "version": "1.0.0",
     "homepage": "http://github.com/bazh/jquery.json-view",
     "description": "Collapsible JSON Viewer",
-    "main": "dist/jquery.json-view.js",
+    "main": [
+        "dist/jquery.json-view.js",
+        "dist/jquery.json-view.css"
+    ],
     "authors": [
         "bazh <interesno@gmail.com>"
     ],
@@ -15,5 +18,5 @@
         "json-view",
         "json-viewer"
     ],
-    "license": "MIT"    
+    "license": "MIT"
 }


### PR DESCRIPTION
Build tools (Grunt in my case) does not correctly detect and package .css if it's not specified in "main" section of bower.json along with .js
